### PR TITLE
Add Navigation to pages

### DIFF
--- a/cradlepoint/components/tables/Table.jsx
+++ b/cradlepoint/components/tables/Table.jsx
@@ -13,11 +13,11 @@ function PlainTable(props) {
     return (
         <div style={{ height: props.height ? props.height : 400, width: '100%' }} className={props.className}>
             <DataGrid
-            rows={props.rows}
-            columns={props.columns}
-            pageSize={5}
-            rowsPerPageOptions={[5]}
-            // onRowClick={props.onRowClick}
+              rows={props.rows}
+              columns={props.columns}
+              pageSize={5}
+              rowsPerPageOptions={[5]}
+              onSelectionModelChange={props.onSelectionModelChange}
             />
         </div>
     )
@@ -34,7 +34,7 @@ function CheckBoxTable(props) {
           pageSize={5}
           rowsPerPageOptions={[5]}
           checkboxSelection
-          onSelectionModelChange={(id) => console.log(id)}
+          onSelectionModelChange={props.onSelectionModelChange}
         />
       </div>
     )

--- a/cradlepoint/pages/2home.jsx
+++ b/cradlepoint/pages/2home.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import PlainScreen from "../components/baseScreen/PlainScreen";
+import { useRouter } from 'next/router'
 import { PlainTable } from "../components/tables/Table";
 import { makeStyles } from '@mui/styles';
 import CPButton from '../components/button/CPButton';
@@ -8,6 +9,7 @@ import { flowType } from './createNewModalFlow/utils';
 import { engagementColumns, engagementRows } from '../util/tableColumns';
 
 export default function HomeScreen(props) {
+    const router = useRouter();
     // TODO: have a consistent style for all the pages (delete later)
     const useStyles = makeStyles({
         root: {
@@ -23,6 +25,11 @@ export default function HomeScreen(props) {
 
         },
       });
+
+    function handleNavigation(id) {
+      router.push("/3EngagementDetails");
+      console.log("/3EngagementDetails/" + id);
+    }
     
     const classes = useStyles();
 
@@ -34,15 +41,14 @@ export default function HomeScreen(props) {
           headerName: 'Actions',
           headerClassName: 'header',
           align: 'center',
-          renderCell: () => (
-            <CPButton text="DETAILS"/>
+          renderCell: (params) => (
+            <CPButton text="DETAILS" onClick={() => handleNavigation(params.id)}/>
           )
         }
       ]);
 
     const [createNewFlow, setCreateNewFlow] = useState(false);
   
-
     return(
       <div >
         <CreateNewModalFlow type={flowType.ENGAGEMENT} modalOpen={createNewFlow} onClose={() => setCreateNewFlow(false)} />

--- a/cradlepoint/pages/3EngagementDetails.jsx
+++ b/cradlepoint/pages/3EngagementDetails.jsx
@@ -1,4 +1,5 @@
 import React, {useState} from 'react';
+import { useRouter } from 'next/router';
 import SplitScreen from '../components/baseScreen/SplitScreen';
 import { PlainTable } from '../components/tables/Table';
 import { makeStyles } from '@mui/styles';
@@ -10,6 +11,7 @@ import CreateNewModalFlow from './createNewModalFlow/createNewModalFlow';
 import { flowType } from './createNewModalFlow/utils';
 
 export default function EngagementDetails() {
+    const router = useRouter();
 
     const useStyles = makeStyles({
         root: {
@@ -30,6 +32,11 @@ export default function EngagementDetails() {
     const [editDescriptionModal, setEditDescriptionModal] = useState(false);
     const [createNewFlow, setCreateNewFlow] = useState(false);
 
+    function handleEditNavigation(id) {
+        router.push("/4TestPlanDetails");
+        console.log("/4TestPlanDetails/" + id);
+    }
+
     //   TODO: style the active test plan
     const testPlanColWithButton = testPlanColumns.concat([
     { 
@@ -37,9 +44,9 @@ export default function EngagementDetails() {
         headerName: 'Actions',
         headerClassName: 'header',
         align: 'center',
-        renderCell: () => (
+        renderCell: (params) => (
         <>
-            <CPButton text="EDIT"/>
+            <CPButton text="EDIT" onClick={() => handleEditNavigation(params.id)}/>
             <CPButton text="SET ACTIVE"/>
         </>
         ),
@@ -57,9 +64,9 @@ export default function EngagementDetails() {
         headerName: 'Actions',
         headerClassName: 'header',
         align: 'center',
-        renderCell: () => (
+        renderCell: (params) => (
         <>
-            <CPButton text="EDIT"/>
+            <CPButton text="EDIT" onClick={() => handleEditNavigation(params.id)}/>
         </>
         ),
         flex: 1

--- a/cradlepoint/pages/4TestPlanDetails.jsx
+++ b/cradlepoint/pages/4TestPlanDetails.jsx
@@ -1,4 +1,5 @@
 import React, {useState} from 'react';
+import { useRouter } from 'next/router';
 import SplitScreen from '../components/baseScreen/SplitScreen';
 import { PlainTable, CheckBoxTable} from '../components/tables/Table';
 import { makeStyles } from '@mui/styles';
@@ -12,6 +13,7 @@ import { BOMColumns, BOMRows, testCaseRows, testCaseColumns} from '../util/table
 import { flowType } from './createNewModalFlow/utils';
 
 export default function TestPlanDetails() {
+    const router = useRouter();
     const [createNewFlow, setCreateNewFlow] = useState(false);
 
     const useStyles = makeStyles({
@@ -30,6 +32,11 @@ export default function TestPlanDetails() {
     
     const classes = useStyles();
 
+    function handleNavigation(id) {
+        router.push("/5TestCaseDetails");
+        console.log("/5TestCaseDetails/" + id);
+    }
+
     const testCaseColumnsWithActions = testCaseColumns.concat([
     { 
         field: 'button', 
@@ -38,7 +45,7 @@ export default function TestPlanDetails() {
         align: 'center',
         renderCell: (params) => (
         <div style={{display: "flex", flexDirection: "row"}}>
-            <CPButton text="View"/>
+            <CPButton text="View" onClick={() => handleNavigation(params.id)}/>
             <CPButton text="Delete"/>
         </div>
         ),

--- a/cradlepoint/pages/5TestCaseDetails.jsx
+++ b/cradlepoint/pages/5TestCaseDetails.jsx
@@ -1,4 +1,5 @@
 import React, {useState} from 'react';
+import { useRouter } from 'next/router';
 import SplitScreen from '../components/baseScreen/SplitScreen';
 import { PlainTable, CheckBoxTable} from '../components/tables/Table';
 import { makeStyles } from '@mui/styles';
@@ -11,6 +12,8 @@ import { BOMColumns, BOMRows, testRows, testColumns} from '../util/tableColumns'
 import { flowType } from './createNewModalFlow/utils';
 
 export default function TestCaseDetails() {
+    const router = useRouter();
+
     const useStyles = makeStyles({
         root: {
           '& .header': {
@@ -26,6 +29,11 @@ export default function TestCaseDetails() {
       });
     
     const classes = useStyles();
+
+    function handleNavigation(id) {
+        router.push("/6TestDetails");
+        console.log("/6TestDetails/" + id);
+    }
     
     const [createNewFlow, setCreateNewFlow] = useState(false);
 
@@ -37,7 +45,7 @@ export default function TestCaseDetails() {
         align: 'center',
         renderCell: (params) => (
         <div style={{display: "flex", flexDirection: "row"}}>
-            <CPButton text="Details"/>
+            <CPButton text="Details" onClick={() => handleNavigation(params.id)}/>
             <CPButton text="Delete"/>
         </div>
         ),


### PR DESCRIPTION
On the `onClick={}` params of the "EDIT" or "VIEW" buttons in the tables, we pass in a function `handleNavigation(id)` to take in an ID to guide navigation to the next page according to the ID. For now, it just goes to the next page as there is yet to be backend support.