### PR TITLE
clean up styling

### DIFF
--- a/cradlepoint/pages/2home.jsx
+++ b/cradlepoint/pages/2home.jsx
@@ -1,37 +1,23 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
+import { makeStyles } from '@mui/styles';
 import PlainScreen from "../components/baseScreen/PlainScreen";
 import { useRouter } from 'next/router'
 import { PlainTable } from "../components/tables/Table";
-import { makeStyles } from '@mui/styles';
 import CPButton from '../components/button/CPButton';
 import CreateNewModalFlow from './createNewModalFlow/createNewModalFlow';
 import { flowType } from './createNewModalFlow/utils';
 import { engagementColumns, engagementRows } from '../util/tableColumns';
+import styling from '../styles/tableStyling';
 
 export default function HomeScreen(props) {
     const router = useRouter();
-    // TODO: have a consistent style for all the pages (delete later)
-    const useStyles = makeStyles({
-        root: {
-          '& .header': {
-            backgroundColor: '#FCAC1C',
-          },
-          '& .MuiDataGrid-iconSeparator': {
-            display: 'None'
-          },
-          '& .MuiDataGrid-columnHeader, .MuiDataGrid-cell': {
-            borderRight: `2px solid #f0f0f0`,
-          },
-
-        },
-      });
+    const useStyles = makeStyles(styling);
+    const classes = useStyles();
 
     function handleNavigation(id) {
       router.push("/3EngagementDetails");
       console.log("/3EngagementDetails/" + id);
     }
-    
-    const classes = useStyles();
 
     const engagementColumnsWithActions = engagementColumns.concat([
         { 

--- a/cradlepoint/pages/3EngagementDetails.jsx
+++ b/cradlepoint/pages/3EngagementDetails.jsx
@@ -9,24 +9,12 @@ import styles from '../styles/EngagementDetails.module.css';
 import EditEDDescription from './engagementDetailsModals/editEDDescriptions';
 import CreateNewModalFlow from './createNewModalFlow/createNewModalFlow';
 import { flowType } from './createNewModalFlow/utils';
+import styling from '../styles/tableStyling';
 
 export default function EngagementDetails() {
     const router = useRouter();
 
-    const useStyles = makeStyles({
-        root: {
-          '& .header': {
-            backgroundColor: '#FCAC1C',
-          },
-          '& .MuiDataGrid-iconSeparator': {
-            display: 'None'
-          },
-          '& .MuiDataGrid-columnHeader, .MuiDataGrid-cell': {
-            borderRight: `2px solid #f0f0f0`,
-          },
-        },
-      });
-    
+    const useStyles = makeStyles(styling);
     const classes = useStyles();
 
     const [editDescriptionModal, setEditDescriptionModal] = useState(false);

--- a/cradlepoint/pages/4TestPlanDetails.jsx
+++ b/cradlepoint/pages/4TestPlanDetails.jsx
@@ -1,34 +1,25 @@
 import React, {useState} from 'react';
 import { useRouter } from 'next/router';
 import SplitScreen from '../components/baseScreen/SplitScreen';
-import { PlainTable, CheckBoxTable} from '../components/tables/Table';
-import { makeStyles } from '@mui/styles';
+import { PlainTable } from '../components/tables/Table';
+
 import CPButton from '../components/button/CPButton';
 import SelectDeviceModal from './deviceModals/selectDevice';
 import SelectQuantityModal from './deviceModals/selectQuantity';
 import CreateNewModalFlow from './createNewModalFlow/createNewModalFlow';
+
+import { makeStyles } from '@mui/styles';
 import styles from '../styles/EngagementDetails.module.css';
+import styling from '../styles/tableStyling';
+
 import { BOMColumns, BOMRows, testCaseRows, testCaseColumns} from '../util/tableColumns';
 import { flowType } from './createNewModalFlow/utils';
 
 export default function TestPlanDetails() {
     const router = useRouter();
     const [createNewFlow, setCreateNewFlow] = useState(false);
-
-    const useStyles = makeStyles({
-        root: {
-          '& .header': {
-            backgroundColor: '#FCAC1C',
-          },
-          '& .MuiDataGrid-iconSeparator': {
-            display: 'None'
-          },
-          '& .MuiDataGrid-columnHeader, .MuiDataGrid-cell': {
-            borderRight: `2px solid #f0f0f0`,
-          },
-        },
-      });
     
+    const useStyles = makeStyles(styling);
     const classes = useStyles();
 
     function handleNavigation(id) {

--- a/cradlepoint/pages/5TestCaseDetails.jsx
+++ b/cradlepoint/pages/5TestCaseDetails.jsx
@@ -10,24 +10,12 @@ import CreateNewModalFlow from './createNewModalFlow/createNewModalFlow';
 import styles from '../styles/EngagementDetails.module.css';
 import { BOMColumns, BOMRows, testRows, testColumns} from '../util/tableColumns';
 import { flowType } from './createNewModalFlow/utils';
+import styling from '../styles/tableStyling';
 
 export default function TestCaseDetails() {
     const router = useRouter();
 
-    const useStyles = makeStyles({
-        root: {
-          '& .header': {
-            backgroundColor: '#FCAC1C',
-          },
-          '& .MuiDataGrid-iconSeparator': {
-            display: 'None'
-          },
-          '& .MuiDataGrid-columnHeader, .MuiDataGrid-cell': {
-            borderRight: `2px solid #f0f0f0`,
-          },
-        },
-      });
-    
+    const useStyles = makeStyles(styling);
     const classes = useStyles();
 
     function handleNavigation(id) {

--- a/cradlepoint/pages/6TestDetails.jsx
+++ b/cradlepoint/pages/6TestDetails.jsx
@@ -1,29 +1,16 @@
 import React, {useState} from 'react';
 import SplitScreen from '../components/baseScreen/SplitScreen';
-import { PlainTable, CheckBoxTable} from '../components/tables/Table';
+import { PlainTable } from '../components/tables/Table';
 import { makeStyles } from '@mui/styles';
 import CPButton from '../components/button/CPButton';
 import styles from '../styles/EngagementDetails.module.css';
-import { BOMColumns, BOMRows, testRows, testColumns, resultColumns, resultRows} from '../util/tableColumns';
+import { resultColumns, resultRows } from '../util/tableColumns';
 import ResultModalForm from './ResultModalForm';
 import TestModalForm from './TestModalForm';
+import styling from '../styles/tableStyling';
 
 export default function TestDetails() {
-
-    const useStyles = makeStyles({
-        root: {
-          '& .header': {
-            backgroundColor: '#FCAC1C',
-          },
-          '& .MuiDataGrid-iconSeparator': {
-            display: 'None'
-          },
-          '& .MuiDataGrid-columnHeader, .MuiDataGrid-cell': {
-            borderRight: `2px solid #f0f0f0`,
-          },
-        },
-      });
-    
+    const useStyles = makeStyles(styling);
     const classes = useStyles();
 
     const resultWithActions = resultColumns.concat([

--- a/cradlepoint/styles/tableStyling.js
+++ b/cradlepoint/styles/tableStyling.js
@@ -1,0 +1,16 @@
+const styling = {
+    root: {
+      '& .header': {
+        backgroundColor: '#FCAC1C',
+      },
+      '& .MuiDataGrid-iconSeparator': {
+        display: 'None'
+      },
+      '& .MuiDataGrid-columnHeader, .MuiDataGrid-cell': {
+        borderRight: `2px solid #f0f0f0`,
+      },
+
+    },
+};
+
+export default styling;


### PR DESCRIPTION
Styles for table are not located in the `styles>tableStyling.js` file, here's an example of using it:
```
    import styling from '../styles/tableStyling';
    const useStyles = makeStyles(styling);
    const classes = useStyles();
```