### PR TITLE
get archived test plans endpoint

### DIFF
--- a/cradlepoint/pages/api/getArchivedTestPlans.js
+++ b/cradlepoint/pages/api/getArchivedTestPlans.js
@@ -1,0 +1,16 @@
+import connectToDb from "../../util/mongodb";
+/*
+ gets the test plans from the library
+*/
+export default async (req, res) => {
+  try {
+    const client = await connectToDb();
+    const cursor = await client.collection("testPlanArchive").find();
+    
+    const results = await cursor.toArray();
+    res.json(results);
+  } catch (err) {
+    res.status(500).send(err);
+  }
+
+};

--- a/cradlepoint/pages/api/getLibraryTestPlans.js
+++ b/cradlepoint/pages/api/getLibraryTestPlans.js
@@ -5,7 +5,7 @@ import connectToDb from "../../util/mongodb";
 export default async (req, res) => {
   try {
     const client = await connectToDb();
-    const cursor = await client.collection("testPlanArchive").find();
+    const cursor = await client.collection("testPlanLibrary").find();
     
     const results = await cursor.toArray();
     res.json(results);


### PR DESCRIPTION
can get all archived test plans from the database, use endpoint http://localhost:3000/api/getLibraryTestPlans to check that the correct data is pulled