### PR TITLE
Export data

### DIFF
--- a/cradlepoint/pages/2home.jsx
+++ b/cradlepoint/pages/2home.jsx
@@ -26,7 +26,7 @@ export default function HomeScreen(props) {
       // export to downloadable json file  
       let dataUri = 'data:application/json;charset=utf-8,'+ encodeURIComponent(dataStr);
 
-      let fileName = 'engagement_' + id +'.json';
+      let fileName = jsonData[0].name +'.json';
 
       let linkElement = document.createElement('a');
       linkElement.setAttribute('href', dataUri);

--- a/cradlepoint/pages/2home.jsx
+++ b/cradlepoint/pages/2home.jsx
@@ -18,17 +18,40 @@ export default function HomeScreen(props) {
       router.push("/3EngagementDetails?_id=" + id);
     }
 
+    async function exportToJson(id) {
+      // get export data
+      const jsonData = await (await fetch(`/api/getEngagementDetails?_id=${id}`)).json();
+      // style json
+      let dataStr = JSON.stringify(jsonData, null, "\t");
+      // export to downloadable json file  
+      let dataUri = 'data:application/json;charset=utf-8,'+ encodeURIComponent(dataStr);
+
+      let fileName = 'engagement_' + id +'.json';
+
+      let linkElement = document.createElement('a');
+      linkElement.setAttribute('href', dataUri);
+      linkElement.setAttribute('download', fileName);
+      linkElement.click();
+    }
+
     const engagementColumnsWithActions = engagementColumns.concat([
         { 
           field: 'button', 
-          flex: 1,
+          flex: 3,
           minWidth: 100,
           headerName: 'Actions',
           headerClassName: 'header',
           align: 'center',
           renderCell: (params) => (
-            <CPButton text="DETAILS" onClick={() => handleNavigation(params.id)}/>
-          )
+            <div style={{display: "flex", flexDirection: "row"}}>
+            <CPButton text="View" onClick={() => handleNavigation(params.id)}/>
+            <CPButton text="Export as json" onClick={() => exportToJson(params.id)}/>
+            <CPButton text="Delete" />
+           </div>
+          ),
+          // renderCell: (params) => (
+          //   <CPButton text="Export" onClick={() => handleNavigation(params.id)}/>
+          // )
         }
       ]);
 

--- a/cradlepoint/pages/3EngagementDetails.jsx
+++ b/cradlepoint/pages/3EngagementDetails.jsx
@@ -36,8 +36,9 @@ export default function EngagementDetails(props) {
         align: 'center',
         renderCell: (params) => (
         <>
-            <CPButton text="EDIT" onClick={() => handleEditNavigation(params.id)}/>
+            <CPButton text="View" onClick={() => handleEditNavigation(params.id)}/>
             <CPButton text="SET ACTIVE"/>
+            <CPButton text="Delete"/>
         </>
         ),
         flex: 1.5
@@ -52,7 +53,7 @@ export default function EngagementDetails(props) {
         align: 'center',
         renderCell: (params) => (
         <>
-            <CPButton text="EDIT" onClick={() => handleEditNavigation(params.id)}/>
+            <CPButton text="View" onClick={() => handleEditNavigation(params.id)}/>
         </>
         ),
         flex: 1
@@ -66,9 +67,10 @@ export default function EngagementDetails(props) {
             headerClassName: 'header',
             align: 'center',
             renderCell: () => (
-            <span>
-                <CPButton text="EDIT"/>
-            </span>
+            <div style={{display: "flex", flexDirection: "row"}}>
+                <CPButton text="View"/>
+                <CPButton text="Delete"/>
+            </div>
             ),
             flex: 1
         }

--- a/cradlepoint/pages/5TestCaseDetails.jsx
+++ b/cradlepoint/pages/5TestCaseDetails.jsx
@@ -36,7 +36,7 @@ export default function TestCaseDetails(props) {
         align: 'center',
         renderCell: (params) => (
         <div style={{display: "flex", flexDirection: "row"}}>
-            <CPButton text="Details" onClick={() => handleNavigation(params.id)}/>
+            <CPButton text="View" onClick={() => handleNavigation(params.id)}/>
             <CPButton text="Delete"/>
         </div>
         ),
@@ -54,7 +54,7 @@ export default function TestCaseDetails(props) {
             renderCell: () => {
                 return (
                     <div style={{display: "flex", flexDirection: "row"}}> 
-                    <CPButton text="Edit"/>
+                    <CPButton text="View"/>
                     <CPButton text="Delete"/>
                     </div>
                 )

--- a/cradlepoint/pages/6TestDetails.jsx
+++ b/cradlepoint/pages/6TestDetails.jsx
@@ -29,7 +29,7 @@ export default function TestDetails(props) {
         align: 'center',
         renderCell: (params) => (
         <div style={{display: "flex", flexDirection: "row"}}>
-            <CPButton text="Details"/>
+            <CPButton text="View"/>
             <CPButton text="Delete"/>
         </div>
         ),

--- a/cradlepoint/pages/DeviceLibrary.jsx
+++ b/cradlepoint/pages/DeviceLibrary.jsx
@@ -21,7 +21,7 @@ export default function DeviceLibrary(props) {
           headerClassName: 'header',
           align: 'center',
           renderCell: () => (
-            <CPButton text="DETAILS"/>
+            <CPButton text="View"/>
           )
         }
       ]);

--- a/cradlepoint/pages/TestCaseLibrary.jsx
+++ b/cradlepoint/pages/TestCaseLibrary.jsx
@@ -22,7 +22,7 @@ export default function TestCaseLibrary(props) {
           headerClassName: 'header',
           align: 'center',
           renderCell: () => (
-            <CPButton text="DETAILS"/>
+            <CPButton text="View"/>
           )
         }
       ]);

--- a/cradlepoint/pages/TestPlanLibrary.jsx
+++ b/cradlepoint/pages/TestPlanLibrary.jsx
@@ -36,7 +36,7 @@ export default function TestPlanLibrary(props) {
           headerClassName: 'header',
           align: 'center',
           renderCell: () => (
-            <CPButton text="DETAILS"/>
+            <CPButton text="View"/>
           )
         }
       ]);
@@ -51,7 +51,6 @@ export default function TestPlanLibrary(props) {
               text="Create New Test Plan"
               onClick={() => setCreateNewFlow(true)}
             />
-            {/* TODO: get rows from database */}
             <PlainTable rows={props.testPlansData} columns={testPlanColumnsWithActions} className={classes.root}/>
 
       </PlainScreen>

--- a/cradlepoint/pages/api/getEngagementDetails.js
+++ b/cradlepoint/pages/api/getEngagementDetails.js
@@ -1,0 +1,68 @@
+const { ObjectId } = require('mongodb');
+import connectToDb from "../../util/mongodb";
+/*
+  Gets export data for an engagement by ID
+  Expand every entity (test plan, test case, test)
+*/
+export default async (req, res) => {
+
+  const query = { 'engagementId': ObjectId(req.query.engagementId),
+                  'isActive': true };
+
+  const client = await connectToDb();
+  const cursor = client.collection("engagements").aggregate([
+    { $match: { "_id": ObjectId(req.query._id) } }, 
+    // look up what the status code represent
+    { $lookup:
+      {
+        from: 'statusCodes',
+        localField: 'statusCode',
+        foreignField: '_id',
+        as: 'status'
+      }
+    },
+    {
+      $set: {
+        status: { $arrayElemAt: ["$status.status", 0] }
+      }
+    },
+    { $lookup:
+      {
+        from: 'testPlan',
+        localField: 'testPlanId',
+        foreignField: '_id',
+        as: 'activeTestPlan'
+      }
+    },
+    {
+      $unwind: "$activeTestPlan"
+    },
+    { $lookup:
+      {
+        from: 'testCases',
+        localField: 'activeTestPlan.testCases',
+        foreignField: '_id',
+        as: 'activeTestPlan.testCases'
+      }
+    },
+    {
+      $unwind: "$activeTestPlan.testCases"
+    },
+    { $lookup:
+      {
+        from: 'tests',
+        localField: 'activeTestPlan.testCases.tests',
+        foreignField: '_id',
+        as: 'activeTestPlan.testCases.tests'
+      }
+    },
+    // filter out the fields we don't want to display
+    { $project: {"_testPlanId":0, "statusCode":0, "activeTestPlan.engagementId":0,
+                "activeTestPlan.summaryBOM.deviceId":0, "activeTestPlan.isActive": 0,
+                "activeTestPlan.authors": 0, "activeTestPlan.testCases.testPlanId":0,
+                "activeTestPlan.testCases.BOM":0, "activeTestPlan.testCases.tests.testCaseId":0,
+                }}
+  ]);
+  const results = await cursor.toArray();
+  res.json(results);
+};


### PR DESCRIPTION
Added feature to export an engagement as json file.
- When user click the _export as json_ button, it automatically downloads a json file with name engagement_<id of the engagement>
![Screen Shot 2022-01-24 at 10 53 07 PM](https://user-images.githubusercontent.com/22091647/150926398-336f6476-0cc7-40f2-9408-33dde065d64e.png)
- The `getEngagementDetails` endpoint shows the details of the lower level entities as well (i.e. test plan, test case, test) by doing nested lookups

Made naming consistent
- renamed all the buttons in the table to **View** instead of Edit or Details
- added **Delete** to the tables (non-functioning)